### PR TITLE
Strengthen types rewrite ld browser

### DIFF
--- a/lib/client/ldBrowser.d.ts
+++ b/lib/client/ldBrowser.d.ts
@@ -1,11 +1,6 @@
-import { Component, ReactNode } from 'react';
-import { LDReactContext as HocState } from '../shared/context';
+import { ReactNode } from 'react';
 declare type LDBrowserProps = {
     children: ReactNode;
 };
-declare class LDBrowser extends Component<LDBrowserProps, HocState> {
-    readonly state: Readonly<HocState>;
-    constructor(props: LDBrowserProps);
-    render(): JSX.Element;
-}
+declare const LDBrowser: (props: LDBrowserProps) => JSX.Element;
 export default LDBrowser;

--- a/lib/client/ldBrowser.js
+++ b/lib/client/ldBrowser.js
@@ -5,27 +5,25 @@ const react_1 = require("react");
 const launchdarkly_js_client_sdk_1 = require("launchdarkly-js-client-sdk");
 const context_1 = require("../shared/context");
 const utils_1 = require("../shared/utils");
-class LDBrowser extends react_1.Component {
-    constructor(props) {
-        super(props);
-        const { ssrFlags, clientSideID, ldUser } = window;
-        console.log(`initializing ld client with ${clientSideID}...`);
-        const ldClient = (0, launchdarkly_js_client_sdk_1.initialize)(clientSideID, ldUser, { bootstrap: ssrFlags, streaming: false });
-        ldClient.on('change', (changes) => {
-            const flattened = (0, utils_1.getFlattenedFlagsFromChangeset)(changes, ssrFlags);
-            if (Object.keys(flattened).length > 0) {
-                this.setState(({ flags }) => ({ flags: Object.assign(Object.assign({}, flags), flattened) }));
-            }
+let ldClient;
+const LDBrowser = (props) => {
+    const { ssrFlags, clientSideID, ldUser } = window;
+    const [state, setState] = (0, react_1.useState)({ flags: ssrFlags,
+        ldClient: undefined,
+        user: ldUser });
+    if (!ldClient) {
+        ldClient = (0, launchdarkly_js_client_sdk_1.initialize)(clientSideID, ldUser, { bootstrap: ssrFlags, streaming: false });
+        ldClient.waitUntilReady().then(() => {
+            setState(({ flags }) => ({ flags, ldClient, user: ldClient.getContext() }));
         });
-        this.state = {
-            flags: ssrFlags,
-            ldClient,
-            user: ldUser,
-        };
     }
-    render() {
-        // eslint-disable-next-line react/react-in-jsx-scope
-        return (0, jsx_runtime_1.jsx)(context_1.Provider, Object.assign({ value: this.state }, { children: this.props.children }));
-    }
-}
+    ldClient.on('change', (changes) => {
+        const flattened = (0, utils_1.getFlattenedFlagsFromChangeset)(changes, ssrFlags);
+        if (Object.keys(flattened).length > 0) {
+            setState(({ flags }) => ({ flags: Object.assign(Object.assign({}, flags), flattened) }));
+        }
+    });
+    // eslint-disable-next-line react/react-in-jsx-scope
+    return (0, jsx_runtime_1.jsx)(context_1.Provider, Object.assign({ value: state }, { children: props.children }));
+};
 exports.default = LDBrowser;

--- a/lib/server/createProvider.d.ts
+++ b/lib/server/createProvider.d.ts
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react';
-import { LDOptions, LDSingleKindContext } from 'launchdarkly-node-server-sdk';
-export declare let ldClient: any;
+import { LDClient, LDOptions, LDSingleKindContext } from 'launchdarkly-node-server-sdk';
+export declare let ldClient: LDClient;
 declare const createProvider: (sdkKey: string, user: LDSingleKindContext, options: LDOptions | undefined) => Promise<({ children }: {
     children: ReactNode;
 }) => JSX.Element>;

--- a/lib/server/createProvider.js
+++ b/lib/server/createProvider.js
@@ -19,11 +19,10 @@ const createProvider = (sdkKey, user, options) => __awaiter(void 0, void 0, void
         yield exports.ldClient.waitForInitialization();
     }
     console.log('Initialized ld node client...');
-    let flags = yield exports.ldClient.allFlagsState(user);
-    flags = flags.toJSON();
+    const flags = yield exports.ldClient.allFlagsState(user);
     const LDProvider = ({ children }) => {
         return ((0, jsx_runtime_1.jsx)(context_1.Provider, Object.assign({ value: {
-                flags,
+                flags: flags.toJSON(),
                 ldClient: exports.ldClient,
                 user,
             } }, { children: children })));

--- a/lib/shared/context.d.ts
+++ b/lib/shared/context.d.ts
@@ -1,11 +1,13 @@
 import type { LDClient as LDJSClient, LDContext, LDFlagSet } from 'launchdarkly-js-client-sdk';
+import type { LDClient as LDNodeClient } from 'launchdarkly-node-server-sdk';
+declare type LDRemixClient = LDJSClient | LDNodeClient | undefined;
 interface LDReactContext {
     flags: LDFlagSet;
-    ldClient?: LDJSClient;
+    ldClient?: LDRemixClient;
     user?: LDContext;
 }
 declare const context: import("react").Context<LDReactContext>;
 declare const Provider: import("react").Provider<LDReactContext>, Consumer: import("react").Consumer<LDReactContext>;
 export { Provider, Consumer };
-export type { LDReactContext };
+export type { LDReactContext, LDRemixClient };
 export default context;

--- a/lib/shared/index.d.ts
+++ b/lib/shared/index.d.ts
@@ -1,5 +1,7 @@
+import type { LDRemixClient } from './context';
 import LDScript from './ldScript';
 import useClient from './useClient';
 import useFlags from './useFlags';
 import useLDUser from './useLDUser';
 export { LDScript, useFlags, useClient, useLDUser };
+export type { LDRemixClient };

--- a/lib/shared/useClient.d.ts
+++ b/lib/shared/useClient.d.ts
@@ -1,3 +1,2 @@
-/// <reference types="launchdarkly-js-client-sdk" />
-declare const useClient: () => import("launchdarkly-js-client-sdk").LDClient | undefined;
+declare const useClient: () => import("./context").LDRemixClient;
 export default useClient;

--- a/src/server/createProvider.tsx
+++ b/src/server/createProvider.tsx
@@ -1,11 +1,10 @@
 /* eslint-disable  @typescript-eslint/no-explicit-any */
 import React, { ReactNode } from 'react';
-import { init, LDOptions,LDSingleKindContext} from 'launchdarkly-node-server-sdk';
+import { init, LDClient, LDOptions,LDSingleKindContext} from 'launchdarkly-node-server-sdk';
 
 import { Provider } from '../shared/context';
 
-// TODO: fix this
-export let ldClient: any;
+export let ldClient: LDClient;
 
 const createProvider = async (sdkKey: string, user: LDSingleKindContext, options: LDOptions | undefined) => {
   if (!ldClient) {
@@ -14,13 +13,12 @@ const createProvider = async (sdkKey: string, user: LDSingleKindContext, options
   }
 
   console.log('Initialized ld node client...');
-  let flags = await ldClient.allFlagsState(user);
-  flags = flags.toJSON();
+  const flags = await ldClient.allFlagsState(user);
   const LDProvider = ({ children }: { children: ReactNode }) => {
     return (
       <Provider
         value={{
-          flags,
+          flags: flags.toJSON(),
           ldClient,
           user,
         }}

--- a/src/shared/context.ts
+++ b/src/shared/context.ts
@@ -1,9 +1,12 @@
 import { createContext } from 'react';
 import type { LDClient as LDJSClient, LDContext, LDFlagSet } from 'launchdarkly-js-client-sdk';
+import type {LDClient as LDNodeClient} from 'launchdarkly-node-server-sdk';
+
+type LDRemixClient = LDJSClient | LDNodeClient | undefined;
 
 interface LDReactContext {
   flags: LDFlagSet;
-  ldClient?: LDJSClient;
+  ldClient?: LDRemixClient
   user?: LDContext;
 }
 
@@ -11,5 +14,5 @@ const context = createContext<LDReactContext>({ flags: {}, ldClient: undefined, 
 const { Provider, Consumer } = context;
 
 export { Provider, Consumer};
-export type {LDReactContext}
+export type {LDReactContext, LDRemixClient}
 export default context;

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -1,6 +1,8 @@
+import type { LDRemixClient } from './context';
 import LDScript from './ldScript';
 import useClient from './useClient';
 import useFlags from './useFlags';
 import useLDUser from './useLDUser';
 
 export { LDScript, useFlags, useClient, useLDUser };
+export type {LDRemixClient}


### PR DESCRIPTION
I rewrote LDBrowser into a functional component that waits for the client to be initialized so that we don’t get the race condition that caused us to get the “identify” warning.